### PR TITLE
Fix tile signal wiring to allow gameplay

### DIFF
--- a/scripts/board_tile.gd
+++ b/scripts/board_tile.gd
@@ -7,7 +7,7 @@ var terrain: String = "plain"
 var occupant: Variant = null
 
 func _ready() -> void:
-    connect("pressed", Callable(self, "_on_pressed"))
+    pressed.connect(_on_pressed)
     _update_visual()
 
 func set_terrain(value: String) -> void:
@@ -30,7 +30,7 @@ func reset_highlight() -> void:
     self.modulate = Color(1, 1, 1)
 
 func _on_pressed() -> void:
-    emit_signal("tile_pressed", grid_position)
+    tile_pressed.emit(grid_position)
 
 func _update_visual() -> void:
     var label_text := ""

--- a/scripts/game_controller.gd
+++ b/scripts/game_controller.gd
@@ -80,7 +80,7 @@ func setup_board() -> void:
             var tile: Button = BoardTileScene.instantiate()
             var pos := Vector2i(x, y)
             tile.grid_position = pos
-            tile.connect("tile_pressed", Callable(self, "_on_tile_pressed"))
+            tile.tile_pressed.connect(_on_tile_pressed)
             board_container.add_child(tile)
             tiles[pos] = tile
             var terrain_type := "plain"


### PR DESCRIPTION
## Summary
- update board tile button signal wiring to use Godot 4 style callbacks
- ensure game controller connects to the custom tile_pressed signal using the new API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5014aa96c8331bdb0a67c92237f4b