### PR TITLE
Fix BoardTile script typing to restore board display

### DIFF
--- a/scripts/board_tile.gd
+++ b/scripts/board_tile.gd
@@ -1,3 +1,4 @@
+class_name BoardTile
 extends Button
 
 signal tile_pressed(position: Vector2i)

--- a/scripts/game_controller.gd
+++ b/scripts/game_controller.gd
@@ -77,7 +77,7 @@ func setup_board() -> void:
 
     for y in range(GRID_SIZE):
         for x in range(GRID_SIZE):
-            var tile: Button = BoardTileScene.instantiate()
+            var tile: BoardTile = BoardTileScene.instantiate()
             var pos := Vector2i(x, y)
             tile.grid_position = pos
             tile.tile_pressed.connect(_on_tile_pressed)


### PR DESCRIPTION
## Summary
- register the BoardTile script with a class_name so it can be referenced by type
- instantiate board tiles using the BoardTile type to preserve access to custom signals

## Testing
- not run (godot4 not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e5063734a88331b2985fa14a0cd1fb