### PR TITLE
Update Godot project for 4.5 compatibility

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -5,7 +5,7 @@ config_version=5
 [application]
 config/name="Origami Tactics"
 run/main_scene="res://scenes/Main.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.5")
 
 [rendering]
 renderer/rendering_method="forward_plus"

--- a/scripts/game_controller.gd
+++ b/scripts/game_controller.gd
@@ -15,8 +15,8 @@ const WATER_TILES := [
 const SHRINE_TILES := [Vector2i(2, 4), Vector2i(6, 4)]
 
 const BASE_POSITIONS := {
-    0: Vector2i(GRID_SIZE - 1, GRID_SIZE / 2),
-    1: Vector2i(0, GRID_SIZE / 2)
+    0: Vector2i(GRID_SIZE - 1, GRID_SIZE // 2),
+    1: Vector2i(0, GRID_SIZE // 2)
 }
 
 const STARTING_UNITS := {


### PR DESCRIPTION
## Summary
- update the project configuration to target Godot 4.5
- adjust base position math to use integer division for Vector2i compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5103944888331a6799dfbf83b1417